### PR TITLE
fix: respect resourceGroup configuration in IBMNodeClass

### DIFF
--- a/pkg/providers/vpc/instance/provider.go
+++ b/pkg/providers/vpc/instance/provider.go
@@ -189,6 +189,13 @@ func (p *VPCInstanceProvider) Create(ctx context.Context, nodeClaim *v1.NodeClai
 		}
 	}
 
+	// Add resource group if specified
+	if nodeClass.Spec.ResourceGroup != "" {
+		instancePrototype.ResourceGroup = &vpcv1.ResourceGroupIdentity{
+			ID: &nodeClass.Spec.ResourceGroup,
+		}
+	}
+
 	// Add SSH keys if specified
 	if len(nodeClass.Spec.SSHKeys) > 0 {
 		var sshKeys []vpcv1.KeyIdentityIntf

--- a/pkg/providers/vpc/instance/resource_group_test.go
+++ b/pkg/providers/vpc/instance/resource_group_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package instance
+
+import (
+	"testing"
+
+	"github.com/IBM/vpc-go-sdk/vpcv1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	"github.com/pfeifferj/karpenter-provider-ibm-cloud/pkg/apis/v1alpha1"
+)
+
+func TestResourceGroupConfiguration(t *testing.T) {
+	tests := []struct {
+		name                    string
+		nodeClassResourceGroup string
+		expectedResourceGroup   *string
+	}{
+		{
+			name:                    "resource group specified",
+			nodeClassResourceGroup: "test-resource-group-id",
+			expectedResourceGroup:   &[]string{"test-resource-group-id"}[0],
+		},
+		{
+			name:                    "resource group empty",
+			nodeClassResourceGroup: "",
+			expectedResourceGroup:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodeClass := &v1alpha1.IBMNodeClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-nodeclass",
+				},
+				Spec: v1alpha1.IBMNodeClassSpec{
+					Region:          "us-south",
+					Zone:            "us-south-1",
+					InstanceProfile: "bx2-4x16",
+					Image:           "test-image-id",
+					VPC:             "test-vpc-id",
+					Subnet:          "test-subnet-id",
+					ResourceGroup:   tt.nodeClassResourceGroup,
+				},
+			}
+
+			nodeClaim := &karpv1.NodeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-nodeclaim",
+				},
+			}
+
+			primaryNetworkInterface := &vpcv1.NetworkInterfacePrototype{
+				Subnet: &vpcv1.SubnetIdentity{
+					ID: &nodeClass.Spec.Subnet,
+				},
+			}
+
+			bootVolumeAttachment := &vpcv1.VolumeAttachmentPrototypeInstanceByImageContext{
+				Volume: &vpcv1.VolumePrototypeInstanceByImageContext{
+					Profile: &vpcv1.VolumeProfileIdentity{
+						Name: &[]string{"general-purpose"}[0],
+					},
+					Capacity: &[]int64{100}[0],
+				},
+				DeleteVolumeOnInstanceDelete: &[]bool{true}[0],
+			}
+
+			instancePrototype := &vpcv1.InstancePrototypeInstanceByImage{
+				Name: &nodeClaim.Name,
+				Zone: &vpcv1.ZoneIdentity{
+					Name: &nodeClass.Spec.Zone,
+				},
+				Profile: &vpcv1.InstanceProfileIdentity{
+					Name: &nodeClass.Spec.InstanceProfile,
+				},
+				VPC: &vpcv1.VPCIdentity{
+					ID: &nodeClass.Spec.VPC,
+				},
+				Image: &vpcv1.ImageIdentity{
+					ID: &nodeClass.Spec.Image,
+				},
+				PrimaryNetworkInterface: primaryNetworkInterface,
+				BootVolumeAttachment:    bootVolumeAttachment,
+			}
+
+			if nodeClass.Spec.ResourceGroup != "" {
+				instancePrototype.ResourceGroup = &vpcv1.ResourceGroupIdentity{
+					ID: &nodeClass.Spec.ResourceGroup,
+				}
+			}
+
+			if tt.expectedResourceGroup != nil {
+				assert.NotNil(t, instancePrototype.ResourceGroup)
+				if resourceGroupIdentity, ok := instancePrototype.ResourceGroup.(*vpcv1.ResourceGroupIdentity); ok {
+					assert.NotNil(t, resourceGroupIdentity.ID)
+					assert.Equal(t, *tt.expectedResourceGroup, *resourceGroupIdentity.ID)
+				} else {
+					t.Errorf("Expected ResourceGroup to be of type *vpcv1.ResourceGroupIdentity")
+				}
+			} else {
+				assert.Nil(t, instancePrototype.ResourceGroup)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The Karpenter IBM Cloud Provider was ignoring the resourceGroup field specified in IBMNodeClass, causing instances to be created in the account's default resource group instead of the specified one.

This fix adds the resourceGroup configuration to the instance prototype when creating VPC instances, ensuring instances are placed in the correct resource group as specified in the IBMNodeClass.

Fixes #141

## Description

<!-- Describe your changes in detail -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Helm chart change
- [ ] Other (please describe)

## Testing

<!-- Please describe the tests you ran to verify your changes -->

- [ ] Unit tests added/updated
- [ ] Helm chart tests pass (`helm lint` and template validation)
- [ ] Tested changes manually
- [ ] Added examples for new features

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant CRDs if needed
- [ ] I have updated the Helm chart version if needed
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional context

<!-- Add any other context about the pull request here -->
