### PR TITLE
feat: add comprehensive drift stability E2E test

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/IBM/go-sdk-core/v5 v5.21.0 h1:DUnYhvC4SoC8T84rx5omnhY3+xcQg/Whyoa3mDPIMkk=
 github.com/IBM/go-sdk-core/v5 v5.21.0/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
-github.com/IBM/platform-services-go-sdk v0.85.1 h1:lrBEeGaIajhSPMB6cPVAx53XTtVGrKOeA36gIXh2FYI=
-github.com/IBM/platform-services-go-sdk v0.85.1/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
 github.com/IBM/platform-services-go-sdk v0.86.1 h1:ngBpaXvUF3gmLvbU1Z4lX1wowOSYgGoKBEBaR/urt30=
 github.com/IBM/platform-services-go-sdk v0.86.1/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
 github.com/IBM/vpc-go-sdk v0.70.1 h1:6NsbRkiA5gDNxe7cjNx8Pi1j9s0PlhwNQj29wsKZxAo=


### PR DESCRIPTION
Add TestE2EDriftStability to verify nodes remain stable after provisioning and don't get incorrectly identified as "drifted".

Key features:
- Creates NodePool with instance-type requirements (bx2-4x16, mx2-2x16)
- Waits for node provisioning and pod scheduling
- Monitors nodes for 12 minutes to ensure no unexpected replacement
- Verifies all NodePool requirements are present as node labels
- Captures node snapshots and tracks ProviderIDs for stability validation
- Detects incorrect drift detection and unexpected node replacements

## Description

<!-- Describe your changes in detail -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Helm chart change
- [ ] Other (please describe)

## Testing

<!-- Please describe the tests you ran to verify your changes -->

- [ ] Unit tests added/updated
- [ ] Helm chart tests pass (`helm lint` and template validation)
- [ ] Tested changes manually
- [ ] Added examples for new features

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant CRDs if needed
- [ ] I have updated the Helm chart version if needed
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional context

<!-- Add any other context about the pull request here -->
