### PR TITLE
fix: inject BOOTSTRAP_* env vars into custom userData scripts

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/IBM/go-sdk-core/v5 v5.21.0 h1:DUnYhvC4SoC8T84rx5omnhY3+xcQg/Whyoa3mDP
 github.com/IBM/go-sdk-core/v5 v5.21.0/go.mod h1:Q3BYO6iDA2zweQPDGbNTtqft5tDcEpm6RTuqMlPcvbw=
 github.com/IBM/platform-services-go-sdk v0.87.0 h1:hLx/I7n7cb1CyAXdb2qypmCoFiYuxh2g50qN8OGnEQc=
 github.com/IBM/platform-services-go-sdk v0.87.0/go.mod h1:aGD045m6I8pfcB77wft8w2cHqWOJjcM3YSSV55BX0Js=
-github.com/IBM/vpc-go-sdk v0.72.0 h1:3Pj7nNuYmlaRPiMyC/5Uro3+5hzNBM6v2Lrq5UABBkQ=
-github.com/IBM/vpc-go-sdk v0.72.0/go.mod h1:K3vVlje72PYE3ZRt1iouE+jSIq+vCyYzT1HiFC06hUA=
 github.com/IBM/vpc-go-sdk v0.73.0 h1:gMVR6NSzw8Y7pCkcDa92+heQTzu5X64q8bnBBpLJpFE=
 github.com/IBM/vpc-go-sdk v0.73.0/go.mod h1:K3vVlje72PYE3ZRt1iouE+jSIq+vCyYzT1HiFC06hUA=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=

--- a/pkg/providers/vpc/bootstrap/cloudinit.go
+++ b/pkg/providers/vpc/bootstrap/cloudinit.go
@@ -927,6 +927,41 @@ report_status "completed" "bootstrap-finished"
 echo "$(date): ===== Bootstrap completed ====="
 `
 
+// InjectBootstrapEnvVars injects BOOTSTRAP_* environment variables into a script
+// This function works with any bash script by inserting exports after the shebang
+func InjectBootstrapEnvVars(script string) string {
+	var bootstrapVars strings.Builder
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "BOOTSTRAP_") {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				varName := parts[0]
+				varValue := parts[1]
+				bootstrapVars.WriteString(fmt.Sprintf("export %s=%q\n", varName, varValue))
+			}
+		}
+	}
+
+	if bootstrapVars.Len() > 0 {
+		fmt.Printf("DEBUG: Injecting %d BOOTSTRAP_* environment variables into script\n",
+			strings.Count(bootstrapVars.String(), "\n"))
+
+		// Handle different shebang styles
+		if strings.HasPrefix(script, "#!/bin/bash\nset -euo pipefail\n") {
+			script = strings.Replace(script, "#!/bin/bash\nset -euo pipefail\n",
+				"#!/bin/bash\nset -euo pipefail\n\n"+bootstrapVars.String(), 1)
+		} else if strings.HasPrefix(script, "#!/bin/bash\n") {
+			script = strings.Replace(script, "#!/bin/bash\n",
+				"#!/bin/bash\n\n"+bootstrapVars.String(), 1)
+		} else {
+			// If no shebang found, prepend to the script
+			script = bootstrapVars.String() + "\n" + script
+		}
+	}
+
+	return script
+}
+
 // generateCloudInitScript generates a cloud-init script for node bootstrapping
 func (p *VPCBootstrapProvider) generateCloudInitScript(ctx context.Context, options types.Options) (string, error) {
 	// Create template
@@ -964,25 +999,8 @@ func (p *VPCBootstrapProvider) generateCloudInitScript(ctx context.Context, opti
 		fmt.Printf("DEBUG: No ca_crt environment variable found\n")
 	}
 
-	// Inject BOOTSTRAP_* environment variables for custom bootstrap scenarios
-	var bootstrapVars strings.Builder
-	for _, env := range os.Environ() {
-		if strings.HasPrefix(env, "BOOTSTRAP_") {
-			parts := strings.SplitN(env, "=", 2)
-			if len(parts) == 2 {
-				varName := parts[0]
-				varValue := parts[1]
-				bootstrapVars.WriteString(fmt.Sprintf("export %s=%q\n", varName, varValue))
-			}
-		}
-	}
-
-	if bootstrapVars.Len() > 0 {
-		fmt.Printf("DEBUG: Injecting %d BOOTSTRAP_* environment variables into cloud-init script\n",
-			strings.Count(bootstrapVars.String(), "\n"))
-		script = strings.Replace(script, "#!/bin/bash\nset -euo pipefail\n",
-			"#!/bin/bash\nset -euo pipefail\n\n"+bootstrapVars.String(), 1)
-	}
+	// Inject BOOTSTRAP_* environment variables
+	script = InjectBootstrapEnvVars(script)
 
 	return script, nil
 }

--- a/pkg/providers/vpc/instance/bootstrap_integration_test.go
+++ b/pkg/providers/vpc/instance/bootstrap_integration_test.go
@@ -83,10 +83,11 @@ func TestBootstrapIntegration(t *testing.T) {
 			)
 
 			if tt.expectManual {
-				// Should return the manual userData as-is
+				// Should return the manual userData with BOOTSTRAP_* variables injected if present
 				assert.NoError(t, err)
-				assert.Equal(t, tt.nodeClass.Spec.UserData, userData)
 				assert.Contains(t, userData, "Manual bootstrap script")
+				// Verify original content is preserved
+				assert.Contains(t, userData, "#!/bin/bash")
 			}
 
 			if tt.expectDynamic {
@@ -126,8 +127,9 @@ func TestBootstrapBehavior(t *testing.T) {
 		)
 
 		assert.NoError(t, err)
-		assert.Equal(t, nodeClass.Spec.UserData, userData)
+		// Verify original custom bootstrap content is preserved
 		assert.Contains(t, userData, "Custom bootstrap")
+		assert.Contains(t, userData, "#!/bin/bash")
 	})
 }
 

--- a/pkg/providers/vpc/instance/provider.go
+++ b/pkg/providers/vpc/instance/provider.go
@@ -1433,7 +1433,8 @@ func (p *VPCInstanceProvider) generateBootstrapUserDataWithInstanceIDAndType(ctx
 	// Use manual userData if provided
 	if nodeClass.Spec.UserData != "" {
 		logger.Info("Using manual userData from IBMNodeClass")
-		return nodeClass.Spec.UserData, nil
+		// Inject BOOTSTRAP_* environment variables into custom userData
+		return bootstrap.InjectBootstrapEnvVars(nodeClass.Spec.UserData), nil
 	}
 
 	// Initialize bootstrap provider if not already done


### PR DESCRIPTION
Changes:
- Extract BOOTSTRAP_* injection logic into reusable InjectBootstrapEnvVars function
- Apply injection to both auto-generated and custom userData paths
- Handle multiple bash shebang styles (with/without set -euo pipefail)
- Maintain backward compatibility with existing bootstrap flows

## Description

<!-- Describe your changes in detail -->

## Type of change

<!-- Please delete options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Helm chart change
- [ ] Other (please describe)

## Testing

<!-- Please describe the tests you ran to verify your changes -->

- [ ] Unit tests added/updated
- [ ] Helm chart tests pass (`helm lint` and template validation)
- [ ] Tested changes manually
- [ ] Added examples for new features

## Checklist

<!-- Please check all that apply -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have updated the relevant CRDs if needed
- [ ] I have updated the Helm chart version if needed
- [ ] I have added tests that prove my fix is effective or that my feature works

## Additional context

<!-- Add any other context about the pull request here -->
